### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,16 +19,16 @@ BrickWork supports almost all the browsers.
 
 ## Developers
 
-###Installation for development
+### Installation for development
 First we have to the requirements.
-####Requirements
+#### Requirements
 + **Node** - First thing you need to have is Node and NPM on you computer.
 + **Gulp** - Install Gulp `npm install gulp -g`
 + **`npm install`** to install the project requirements.
 
 I have used `gulp-rigger` to organize the code. `src` is the directory where the entire code is written. `src/brickwork.js` is main file which is compiled as `brickwork.js` and `brickwork.min.js`
 
-###Running the code
+### Running the code
 After the installation of the requirement you just need and when you have completed your changes you just need to follow.
 
 + Run `gulp rig` to make to compile the code to `brickwork.js`


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
